### PR TITLE
Added logic to auto-join a secondary UID to a syncshell

### DIFF
--- a/MareSynchronosServer/MareSynchronosServices/Discord/ShoninWizardModule.Secondary.cs
+++ b/MareSynchronosServer/MareSynchronosServices/Discord/ShoninWizardModule.Secondary.cs
@@ -4,6 +4,7 @@ using MareSynchronosShared.Data;
 using Microsoft.EntityFrameworkCore;
 using MareSynchronosShared.Models;
 using MareSynchronosShared.Utils;
+using MareSynchronosShared.Utils.Configuration;
 
 namespace MareSynchronosServices.Discord;
 
@@ -80,6 +81,15 @@ public partial class ShoninWizardModule
         await db.Auth.AddAsync(auth).ConfigureAwait(false);
 
         await db.SaveChangesAsync().ConfigureAwait(false);
+        
+        var guildId = Context.Guild.Id;
+        var guildSettings = _mareServicesConfiguration.GetValue<List<DiscordServerConfiguration>>("ServerConfigurations");
+        var guildConfig = guildSettings.FirstOrDefault(x => x.ServerId == guildId);
+        if (guildConfig != null)
+        {
+            var syncshell = await db.Groups.FirstOrDefaultAsync(x => x.Alias.Equals(guildConfig.SyncshellVanityId)).ConfigureAwait(false);
+            await _syncshellManager.JoinSyncshell(syncshell.GID, newUser.UID).ConfigureAwait(false);
+        }
 
         embed.WithDescription("A secondary UID for you was created, use the information below and add the secret key to the Shonin Sync setings in the Service Settings tab.");
         embed.AddField("UID", newUser.UID);


### PR DESCRIPTION
Added logic to auto-join a secondary UID to a syncshell

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Secondary accounts now automatically synchronize with guild-specific configurations upon creation when a matching configuration exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->